### PR TITLE
Exports the action & state space for gridworld and adds additional clarifying comments

### DIFF
--- a/src/POMDPModels.jl
+++ b/src/POMDPModels.jl
@@ -53,6 +53,7 @@ export
     GridWorldState,
     GridWorldAction,
     GridWorldActionSpace,
+    GridWorldStateSpace,
     GridWorldDistribution,
     static_reward,
     plot

--- a/src/POMDPModels.jl
+++ b/src/POMDPModels.jl
@@ -52,6 +52,7 @@ export
     GridWorld,
     GridWorldState,
     GridWorldAction,
+    GridWorldActionSpace,
     GridWorldDistribution,
     static_reward,
     plot


### PR DESCRIPTION
Exports the GridWorldActionSpace and GridWorldStateSpace to be used by clients of this code (similar to other models that already have these exposed), as is needed for clients to interact with the action spaces & state spaces. Also adds two types of clarifying comments to the GridWorld itself: (1) how the "bounds penalty" is used (is the penalty expected to be negative or positive?) and (2) how transition function works.