### PR TITLE
Bool

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,7 @@ julia 0.6
 Distributions
 POMDPs 0.6
 TikzPictures
-POMDPToolbox 0.2 0.2.6
+POMDPToolbox 0.2.6
 AutoHashEquals
 StaticArrays
 StatsBase 0.15

--- a/src/POMDPModels.jl
+++ b/src/POMDPModels.jl
@@ -57,7 +57,6 @@ export
 include("CryingBabies.jl")
 export
     BabyPOMDP,
-    BoolDistribution,
     BabyBeliefUpdater,
     Starve,
     AlwaysFeed,

--- a/src/TigerPOMDPs.jl
+++ b/src/TigerPOMDPs.jl
@@ -20,22 +20,6 @@ const TIGER_OPEN_RIGHT = 2
 const TIGER_LEFT = true
 const TIGER_RIGHT = false
 
-mutable struct TigerDistribution
-    p::Float64
-    it::Vector{Bool}
-end
-TigerDistribution() = TigerDistribution(0.5, [true, false])
-iterator(d::TigerDistribution) = d.it
-
-#Base.length(d::AbstractTigerDistribution) = d.interps.length
-#weight(d::AbstractTigerDistribution, i::Int64) = d.interps.weights[i]
-#index(d::AbstractTigerDistribution, i::Int64) = d.interps.indices[i]
-
-function pdf(d::TigerDistribution, so::Bool)
-    so ? (return d.p) : (return 1.0-d.p)
-end
-
-rand(rng::AbstractRNG, d::TigerDistribution) = rand(rng) <= d.p
 
 n_states(::TigerPOMDP) = 2
 n_actions(::TigerPOMDP) = 3
@@ -43,26 +27,26 @@ n_observations(::TigerPOMDP) = 2
 
 # Resets the problem after opening door; does nothing after listening
 function transition(pomdp::TigerPOMDP, s::Bool, a::Int64)
-    d = TigerDistribution()
+    p = 1.0
     if a == 1 || a == 2
-        d.p = 0.5
+        p = 0.5
     elseif s
-        d.p = 1.0
+        p = 1.0
     else
-        d.p = 0.0
+        p = 0.0
     end
-    d
+    return BoolDistribution(p)
 end
 
 function observation(pomdp::TigerPOMDP, a::Int64, sp::Bool)
-    d = TigerDistribution()
     pc = pomdp.p_listen_correctly
+    p = 1.0
     if a == 0
-        sp ? (d.p = pc) : (d.p = 1.0-pc)
+        sp ? (p = pc) : (p = 1.0-pc)
     else
-        d.p = 0.5
+        p = 0.5
     end
-    d
+    return BoolDistribution(p)
 end
 
 function observation(pomdp::TigerPOMDP, s::Bool, a::Int64, sp::Bool)
@@ -84,7 +68,7 @@ end
 reward(pomdp::TigerPOMDP, s::Bool, a::Int64, sp::Bool) = reward(pomdp, s, a)
 
 
-initial_state_distribution(pomdp::TigerPOMDP) = TigerDistribution(0.5, [true, false])
+initial_state_distribution(pomdp::TigerPOMDP) = BoolDistribution(0.5)
 
 actions(::TigerPOMDP) = [0,1,2]
 
@@ -98,30 +82,3 @@ function generate_o(p::TigerPOMDP, s::Bool, rng::AbstractRNG)
     d = observation(p, 0, s) # obs distrubtion not action dependant
     return rand(rng, d)
 end
-
-# This doesn't seem to work well
-# type TigerBeliefUpdater <: Updater
-#     pomdp::TigerPOMDP
-# end
-#
-# function update(bu::TigerBeliefUpdater, bold::DiscreteBelief, a::Int64, o::Bool)
-#     bl = bold[1]
-#     br = bold[2]
-#     p = bu.pomdp.p_listen_correctly
-#     if a == 0
-#         if o
-#             bl *= p
-#             br *= (1.0-p)
-#         else
-#             bl *= (1.0-p)
-#             br *= p
-#         end
-#     else
-#         bl = 0.5
-#         br = 0.5
-#     end
-#     norm = bl+br
-#     b[1] = bl / norm
-#     b[2] = br / norm
-#     b
-# end

--- a/test/crying.jl
+++ b/test/crying.jl
@@ -25,11 +25,12 @@ o = convert_s(Bool, ov, problem)
 
 probability_check(problem)
 
-bp =  update(BabyBeliefUpdater(problem),
-             BoolDistribution(0.0),
+bu = DiscreteUpdater(problem)
+bp =  update(bu,
+             initialize_belief(bu, BoolDistribution(0.0)),
              false,
              true)
 
-@test bp.p ≈ 0.47058823529411764 atol=0.0001
-r = simulate(sim, problem, policy, BabyBeliefUpdater(problem), BoolDistribution(1.0))
+@test pdf(bp, true) ≈ 0.47058823529411764 atol=0.0001
+r = simulate(sim, problem, policy, DiscreteUpdater(problem), BoolDistribution(1.0))
 @test r ≈ -100.0 atol=0.01

--- a/test/gridworld.jl
+++ b/test/gridworld.jl
@@ -9,10 +9,10 @@ policy = RandomPolicy(problem)
 
 sim = HistoryRecorder(rng=MersenneTwister(1), max_steps=1000)
 
-simulate(sim, problem, policy, GridWorldState(1,1))
+hist = simulate(sim, problem, policy, GridWorldState(1,1))
 
-for i in 1:length(sim.action_hist)
-    td = transition(problem, sim.state_hist[i], sim.action_hist[i])
+for i in 1:length(hist.action_hist)
+    td = transition(problem, hist.state_hist[i], hist.action_hist[i])
     @test sum(td.probs) ≈ 1.0 atol=0.01
     for p in td.probs
         @test p >= 0.0


### PR DESCRIPTION
Uses `BoolDistribution` instead of custom types for Baby and Tiger problems. This makes the code simpler. Also, since `BoolDistribution` is now defined in POMDPToolbox, the definition in CryingBabies.jl has to be removed or the definitions will conflict.