### PR TITLE
TMaze bugfix: terminal states

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "POMDPModels"
 uuid = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
 repo = "https://github.com/JuliaPOMDP/POMDPModels.jl"
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 BeliefUpdaters = "8bb6e9a1-7d73-552c-a44a-e5dc5634aac4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "POMDPModels"
 uuid = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
 repo = "https://github.com/JuliaPOMDP/POMDPModels.jl"
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 BeliefUpdaters = "8bb6e9a1-7d73-552c-a44a-e5dc5634aac4"

--- a/src/TMazes.jl
+++ b/src/TMazes.jl
@@ -51,7 +51,7 @@ function create_transition_distribution(::TMaze)
     rp = [0.5, 0.5]
     TMazeStateDistribution(TMazeState(), false, rs, rp)
 end
-support(d::TMazeStateDistribution) = d.reset ? (return [(d.current_state, 1.0)]) : (return zip(d.reset_states, d.reset_probs))
+support(d::TMazeStateDistribution) = d.reset ? (return [d.current_state]) : (return zip(d.reset_states, d.reset_probs))
 
 function pdf(d::TMazeStateDistribution, s::TMazeState)
     if d.reset
@@ -259,13 +259,4 @@ function POMDPs.action(p::MazeOptimal, b::MazeBelief)
         return 3
     end
     return 2
-end
-
-function pdf(d::TMazeStateDistribution, st::Tuple{TMazeState, Float64})
-    @warn "pdf: Get rid of this function, just a temporary helper to make sparse_tabular.jl tests pass"
-    return pdf(d, st[1])
-end
-function stateindex(m::TMaze, st::Tuple{TMazeState, Float64})
-    @warn "stateindex: Get rid of this function, just a temporary helper to make sparse_tabular.jl tests pass"
-    return stateindex(m, st[1])
 end

--- a/src/TMazes.jl
+++ b/src/TMazes.jl
@@ -1,4 +1,4 @@
-@with_kw struct TMazeState
+@with_kw mutable struct TMazeState
     x::Int64 = 1 # position in corridor
     g::Symbol = :north# goal north or south
     term::Bool = false
@@ -90,7 +90,7 @@ end
 function rand(rng::AbstractRNG, d::TMazeInit)
     cat = Weights(d.probs)
     idx = sample(rng, cat)
-    return d.states[idx])
+    return d.states[idx]
 end
 function pdf(d::TMazeInit, s::TMazeState)
     for i = 1:length(d.states)


### PR DESCRIPTION
Discovered several problems when running test set from `SparseTabularPOMDP` in POMDPModelTools.jl.
 - mapping to terminal state was not correct
 - actionindex, observationindex were missing    

For some reason, `stateindex` and `pdf` are called with an argument of type `Tuple{TMazeState, Float64}` in `test/test_tabular.jl` (POMDPModelTools.jl) and I was not able to track down where that call was initiated from. I temporarily added two functions that satisfy this interface, but they should probably be removed again before this issue is closed.

I think the transition matrix violates the assumption that a terminal state cannot be escaped (check conditions based on `d.reset` in the `transition` function)