### PR TITLE
reversed tiger state and observation order so that it matches stateindex

### DIFF
--- a/src/TigerPOMDPs.jl
+++ b/src/TigerPOMDPs.jl
@@ -7,8 +7,8 @@ mutable struct TigerPOMDP <: POMDP{Bool, Int64, Bool}
 end
 TigerPOMDP() = TigerPOMDP(-1.0, -100.0, 10.0, 0.85, 0.95)
 
-states(::TigerPOMDP) = (true, false)
-observations(::TigerPOMDP) = (true, false)
+states(::TigerPOMDP) = (false, true)
+observations(::TigerPOMDP) = (false, true)
 
 stateindex(::TigerPOMDP, s::Bool) = Int64(s) + 1
 actionindex(::TigerPOMDP, a::Int) = a + 1
@@ -20,14 +20,13 @@ const TIGER_LISTEN = 0
 const TIGER_OPEN_LEFT = 1
 const TIGER_OPEN_RIGHT = 2
 
-const TIGER_LEFT = true
-const TIGER_RIGHT = false
+const TIGER_LEFT = false
+const TIGER_RIGHT = true
 
 
 # Resets the problem after opening door; does nothing after listening
 function transition(pomdp::TigerPOMDP, s::Bool, a::Int64)
-    p = 1.0
-    if a == 1 || a == 2
+    if a == TIGER_OPEN_LEFT || a == TIGER_OPEN_RIGHT
         p = 0.5
     elseif s
         p = 1.0
@@ -40,7 +39,7 @@ end
 function observation(pomdp::TigerPOMDP, a::Int64, sp::Bool)
     pc = pomdp.p_listen_correctly
     p = 1.0
-    if a == 0
+    if a == TIGER_LISTEN
         sp ? (p = pc) : (p = 1.0-pc)
     else
         p = 0.5
@@ -55,12 +54,12 @@ end
 
 function reward(pomdp::TigerPOMDP, s::Bool, a::Int64)
     r = 0.0
-    a == 0 ? (r+=pomdp.r_listen) : (nothing)
-    if a == 1
-        s ? (r += pomdp.r_findtiger) : (r += pomdp.r_escapetiger)
+    a == TIGER_LISTEN ? (r+=pomdp.r_listen) : (nothing)
+    if a == TIGER_OPEN_LEFT
+        s == TIGER_LEFT ? (r += pomdp.r_findtiger) : (r += pomdp.r_escapetiger)
     end
-    if a == 2
-        s ? (r += pomdp.r_escapetiger) : (r += pomdp.r_findtiger)
+    if a == TIGER_OPEN_RIGHT
+        s == TIGER_RIGHT ? (r += pomdp.r_findtiger) : (r += pomdp.r_escapetiger)
     end
     return r
 end

--- a/test/tiger.jl
+++ b/test/tiger.jl
@@ -32,4 +32,24 @@ let
 
     @test has_consistent_distributions(pomdp1)
     @test has_consistent_distributions(pomdp2)
+
+    @test reward(pomdp1, TIGER_LEFT, TIGER_OPEN_LEFT) == pomdp1.r_findtiger
+    @test reward(pomdp1, TIGER_LEFT, TIGER_OPEN_RIGHT) == pomdp1.r_escapetiger
+    @test reward(pomdp1, TIGER_RIGHT, TIGER_OPEN_RIGHT) == pomdp1.r_findtiger
+    @test reward(pomdp1, TIGER_RIGHT, TIGER_OPEN_LEFT) == pomdp1.r_escapetiger
+    @test reward(pomdp1, TIGER_RIGHT, TIGER_LISTEN) == pomdp1.r_listen
+
+    for s in states(pomdp1)
+        @test pdf(transition(pomdp1, s, TIGER_LISTEN), s) == 1.0
+        @test pdf(transition(pomdp1, s, TIGER_OPEN_LEFT), s) == 0.5
+        @test pdf(transition(pomdp1, s, TIGER_OPEN_RIGHT), s) == 0.5
+    end
+
+    for s in states(pomdp1)
+        @test pdf(observation(pomdp1, TIGER_LISTEN, s), s) == pomdp1.p_listen_correctly
+        @test pdf(observation(pomdp1, TIGER_OPEN_LEFT, s), s) == 0.5
+        @test pdf(observation(pomdp1, TIGER_OPEN_RIGHT, s), s) == 0.5
+    end
+
+
 end

--- a/test/tiger.jl
+++ b/test/tiger.jl
@@ -22,7 +22,7 @@ let
 
     simulate(sim, pomdp1, policy, updater(policy), initialstate(pomdp1))
 
-    o = first(observations(pomdp1))
+    o = last(observations(pomdp1))
     @test o == 1
     # test vec
     ov = convert_o(Array{Float64}, true, pomdp1)


### PR DESCRIPTION
`states` not agreeing with `stateindex` is always an unnecessary annoyance for students in my DMU class