### PR TITLE
Faster SimpleGridWorld Transition

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,9 +1,7 @@
 [deps]
 Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
-POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 POMDPTools = "7588e00f-9cae-40de-98dc-e0c70c48cdd7"
+POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[compat]
-POMDPTools = "0.1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using POMDPTools
 using Random
 using Test
 using Compose
+using StaticArrays
 
 @testset "crying" begin
     include("crying.jl")


### PR DESCRIPTION
Heap allocated `MVector`'s used previously sometimes became a bottleneck in planning due to garbage collection.

This implementation is entirely stack allocated, pushing GC time to a consistent 0.0%.

The only hangup for merging this would be maintainability and implementation simplicity.

I also added tests to make sure that the distributions yielded by both this transition function and the previous one are the same.

## Benchmark
```julia
using POMDPs, POMDPModels, BenchmarkTools

mdp = SimpleGridWorld()
s = GWPos(1,1)
a = :up

@benchmark transition($mdp, $s, $a)
```

### Before
```julia
BenchmarkTools.Trial: 10000 samples with 995 evaluations.
 Range (min … max):  27.848 ns …   2.645 μs  ┊ GC (min … max):  0.00% … 98.16%
 Time  (median):     29.774 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):   39.566 ns ± 151.996 ns  ┊ GC (mean ± σ):  23.50% ±  6.02%

         ▁███▆▄▂                                                
  ▂▂▃▄▄▄▆████████▇▆▅▄▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂ ▃
  27.8 ns         Histogram: frequency by time         38.2 ns <

 Memory estimate: 176 bytes, allocs estimate: 3.
```

### After
```julia
BenchmarkTools.Trial: 10000 samples with 998 evaluations.
 Range (min … max):  17.368 ns … 41.249 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     17.452 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   17.507 ns ±  0.482 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▅ █ ▆ ▅ ▃                                                  ▁
  ██▁█▁█▁█▁█▁█▄▁▃▁▄▁▄▁▁▁▄▁▁▁▁▄▁▆▁▇▁▆▁▅▄▁▅▁▅▁▄▁▅▁▅▄▁▅▁▃▁▄▁▄▁▅▆ █
  17.4 ns      Histogram: log(frequency) by time      18.7 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```