### PR TITLE
Fix Base.hash to use only the two-arg method

### DIFF
--- a/src/legacy/GridWorlds.jl
+++ b/src/legacy/GridWorlds.jl
@@ -34,7 +34,7 @@ function ==(s1::GridWorldState,s2::GridWorldState)
 end
 # for hashing states in dictionaries in Monte Carlo Tree Search
 posequal(s1::GridWorldState, s2::GridWorldState) = s1.x == s2.x && s1.y == s2.y
-function hash(s::GridWorldState, h::UInt64 = zero(UInt64))
+function hash(s::GridWorldState, h::UInt)
     if s.done
         return hash(s.done, h)
     else


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

`Base.hash` should only be extended via the two-arg method `hash(x, h::UInt)`.
Defining a one-arg `hash(x)` method, or giving the second argument a default
value, can lead to correctness bugs (hash contract violations when the seed
differs from the hard-coded default) and invalidation-related performance
issues. This is particularly necessary for Julia 1.13+ where the default hash
seed value will change.

This PR was generated with the assistance of generative AI.